### PR TITLE
ARM: dts: 15801: Disable core hotplugging, up the mitigation freq

### DIFF
--- a/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
@@ -1066,6 +1066,14 @@
 		android,ramoops-dump-oops = <0x1>;
 		linux,contiguous-region = <&ramoops_mem>;
 	};
+
+	qcom,bcl {
+		/delete-property/ qcom,bcl-hotplug-list;
+		/delete-property/ qcom,bcl-soc-hotplug-list;
+		qcom,ibat-monitor {
+			qcom,mitigation-freq-khz = <1132800>;
+		};
+	};
 };
 
 // msm8996-ipcrouter.dtsi


### PR DESCRIPTION
Don't throttle as much, don't hotplug cores. There are two potential
cases:

1) The screen is off and the device is in deep sleep. The cores will
actually be disabled as the device enters a sleep state so the BCL is
useless.

2) The user is actively using the device. We hotplug out the third core
and throttle the rest to ~500mhz. While this may seem a good idea, the
device actually becomes unusable and takes longer to complete tasks and
go back to low power states, which actually makes the problem worse.

This patch disables hotplugging and ups the throttle freq to 1132800
which makes the phone usable while skipping the higher freq states.

Change-Id: I07ca3c62d53c65f4197ce6627f29f722d39f2c28